### PR TITLE
AST - block params capture for ElementNode

### DIFF
--- a/ast-examples.md
+++ b/ast-examples.md
@@ -13,6 +13,33 @@ https://github.com/adopted-ember-addons/ember-cli-hot-loader
 
 refs [astexporer](https://astexplorer.net/#/gist/9cdbd763be462d0b76ed6f442f62d5fe/b84f902de115f4cc32d43b9b4d9170067ed391b3)
 
+```hbs 
+<FooBar />
+<Baz as |ctx|>
+  <ctx.boo />
+</Baz>
+<Boo as |Foo|>
+	<Foo />
+</Boo>
+```
+
+to 
+
+```hbs
+{{#let (component 'foobar') as |FooBar|}}
+  <FooBar />
+{{/let}}
+{{#let (component 'baz') as |Baz|}}
+  <Baz as |ctx|>
+    <ctx.boo />
+  </Baz>
+{{/let}}
+{{#let (component 'boo') as |boo|}}
+  <Boo as |Foo|>
+	  <Foo />
+  </Boo>
+{{/let}}
+```
 
 ```hbs
 {{component 'foo-bar' a="1"}}
@@ -24,25 +51,27 @@ refs [astexporer](https://astexplorer.net/#/gist/9cdbd763be462d0b76ed6f442f62d5f
 dsfsd
 {{/foo-boo}}
 {{doo-bar 1 2 3 hoo-boo name=(goo-boo "foo")}}
-{{component (hot-load "foo-bar") baz="stuff"}}
 {{test-component}}
-{{test-component}}
-{{test-component}}
+{{component @fooBar}}
+{{component this.fooBar}}
+{{component fooBar}}
+{{component args.fooBar}}
 ```
 
 will be transformed to 
-
 
 ```hbs
 {{component (hot-load "foo-bar") a="1"}}
 {{component (hot-load (mut 1 2 3)) b c d e="f"}}
 {{component (hot-load "foo-bar") baz="stuff"}}
 {{#component (hot-load "foo-boo")}}dsfsd
-{{/component}}{{component (hot-load "doo-bar") 1 2 3 hoo-boo name=(goo-boo "foo")}}
-{{component (hot-load "foo-bar") baz="stuff"}}
+{{/component}}
+{{component (hot-load "doo-bar") 1 2 3 hoo-boo name=(goo-boo "foo")}}
 {{component (hot-load "test-component")}}
-{{component (hot-load "test-component")}}
-{{component (hot-load "test-component")}}
+{{component (hot-load @fooBar)}}
+{{component (hot-load this.fooBar)}}
+{{component (hot-load fooBar)}}
+{{component (hot-load args.fooBar)}}
 ```
 
 and `hot-load` helper will manage component reloading

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -221,9 +221,22 @@ function markNodeAsIgnored(node) {
   return node;
 }
 
+function captureBlockParams(node) {
+	const params = node.blockParams;
+    if (node.__ignore) {
+       return;
+    }
+    params.forEach((param)=>{
+       if (!nestedNames.includes(param)) {
+         nestedNames.push(param);
+       }
+     });
+}
+
 function wrapAngeBrackedComponentWithLetHelper(b, node) {
   const tagName = node.tag;
   const newNode = JSON.parse(JSON.stringify(node));
+  captureBlockParams(node);
   newNode.cloned = true;
   node.type = "BlockStatement";
   node.params = [
@@ -269,15 +282,7 @@ module.exports = function (env, options) {
         });
       },
       Program(node) {
-        const params = node.blockParams;
-        if (node.__ignore) {
-          return;
-        }
-        params.forEach((param)=>{
-          if (!nestedNames.includes(param)) {
-            nestedNames.push(param);
-          }
-        });
+        captureBlockParams(node);
       },
       ElementNode(node) {
         node.attributes.forEach(attr => {


### PR DESCRIPTION
Cover cases like this:
```hbs
 <Boo as |Foo|>
 	<Foo />
 </Boo>
```