### PR TITLE
improved let support for ember 2.16 - 3.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/node_modules/ember-cli/bin/ember",
+            "args": ["serve"],
+        }
+    ]
+}

--- a/addon/helpers/hot-load.js
+++ b/addon/helpers/hot-load.js
@@ -57,7 +57,6 @@ export default Helper.extend({
     hotLoader.unregisterWillLiveReload(this.binded__willLiveReload);
   },
   compute([name, context = {}, maybePropertyValue = undefined, astStringName = '']) {
-
     const hotLoader = get(this, 'hotLoader');
     const safeAstName = String(astStringName || '');
     const renderComponentName = hotLoader.normalizeComponentName(name);

--- a/addon/helpers/hot-load.js
+++ b/addon/helpers/hot-load.js
@@ -57,6 +57,7 @@ export default Helper.extend({
     hotLoader.unregisterWillLiveReload(this.binded__willLiveReload);
   },
   compute([name, context = {}, maybePropertyValue = undefined, astStringName = '']) {
+
     const hotLoader = get(this, 'hotLoader');
     const safeAstName = String(astStringName || '');
     const renderComponentName = hotLoader.normalizeComponentName(name);

--- a/addon/services/hot-loader.js
+++ b/addon/services/hot-loader.js
@@ -216,6 +216,12 @@ export default Service.extend(Evented, {
       this.willLiveReloadRouteTemplate(attrs);
     }
   },
+  _willHotReloadCallbacksCount() {
+    return willHotReloadCallbacks.length;
+  },
+  _willLiveReloadCallbacksCount() {
+    return willLiveReloadCallbacks.length;
+  },
   registerWillHotReload(fn) {
     willHotReloadCallbacks.push(fn);
   },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,11 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-	// Add options here
+  // Add options here
+    'ember-ast-hot-load': {
+      helpers: ["my-zoo"],
+      enabled: true
+    }
   });
 
   if (app.env === 'test') {

--- a/index.js
+++ b/index.js
@@ -30,21 +30,21 @@ module.exports = {
     if (!this.isEnabled()) {
       return;
     }
-    // console.log('type', type);
-    let pluginObj = this._buildPlugin(this._OPTIONS);
+    let pluginObj = this._buildPlugin({addonContext: this});
+    //parallelBabel proper integration?
     pluginObj.parallelBabel = {
       requireFile: __filename,
       buildUsing: "_buildPlugin",
-      params: { }
+      params: { addonContext: this }
     };
     registry.add("htmlbars-ast-plugin", pluginObj);
   },
 
-  _buildPlugin() {
-    // console.log('_buildPlugin', opts);
+  _buildPlugin({addonContext}) {
+    const plugin = require("./lib/ast-transform")({addonContext});
     return {
       name: "ember-ast-hot-load-babel-plugin",
-      plugin: require("./lib/ast-transform"),
+      plugin,
       baseDir() {
         return __dirname;
       }
@@ -141,6 +141,7 @@ module.exports = {
     };
   },
   included(app) {
+    // console.log('included');
     this._super.included.apply(this, arguments);
     let host = this._findHost();
     this._assignOptions(host);

--- a/index.js
+++ b/index.js
@@ -120,12 +120,13 @@ module.exports = {
     if (env === 'test' || env === 'production') {
       enabled = false;
     }
-    this._OPTIONS = {
+    this._OPTIONS = Object.assign(this._OPTIONS, {
       helpers,
       enabled,
       watch,
       templateCompilerPath
-    };
+    });
+    this._OPTIONS.initialized = true;
     this._isDisabled = !enabled;
   },
   importTransforms() {

--- a/index.js
+++ b/index.js
@@ -30,28 +30,21 @@ module.exports = {
     if (!this.isEnabled()) {
       return;
     }
-    let pluginObj = this._buildPlugin();
+    // console.log('type', type);
+    let pluginObj = this._buildPlugin(this._OPTIONS);
     pluginObj.parallelBabel = {
       requireFile: __filename,
       buildUsing: "_buildPlugin",
-      params: {}
+      params: { }
     };
     registry.add("htmlbars-ast-plugin", pluginObj);
   },
 
-  _buildPlugin() {
-    const _this = this;
+  _buildPlugin(opts) {
+    console.log('_buildPlugin', opts);
     return {
       name: "ember-ast-hot-load-babel-plugin",
-      plugin(env) {
-        if (!_this._OPTIONS.enabled) {
-          return function () {};
-        }
-        if (!_this.isEnabled()) {
-          return function () {};
-        }
-        return require("./lib/ast-transform").call(this, env, _this._OPTIONS);
-      },
+      plugin: require("./lib/ast-transform"),
       baseDir() {
         return __dirname;
       }

--- a/index.js
+++ b/index.js
@@ -118,7 +118,10 @@ module.exports = {
       templateCompilerPath = undefined
     } = currentOptions;
     if (env === 'test' || env === 'production') {
-      enabled = false;
+      // allow test/prod addon usage only for app, named "dummy" (addon test app)
+      if (app.name !== 'dummy') {
+        enabled = false;
+      }
     }
     this._OPTIONS = Object.assign(this._OPTIONS, {
       helpers,
@@ -216,9 +219,6 @@ module.exports = {
   //   }
   // },
   treeForVendor(rawVendorTree) {
-    if (this._ENV && this._ENV === 'production') {
-      this._isDisabled = true;
-    }
     if (this.isDisabled()) {
       return this._super.treeForVendor.apply(this, arguments);
     }

--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ module.exports = {
     registry.add("htmlbars-ast-plugin", pluginObj);
   },
 
-  _buildPlugin(opts) {
-    console.log('_buildPlugin', opts);
+  _buildPlugin() {
+    // console.log('_buildPlugin', opts);
     return {
       name: "ember-ast-hot-load-babel-plugin",
       plugin: require("./lib/ast-transform"),

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ module.exports = {
   _assignOptions(app) {
     let appOptions = app.options || {};
     let addonOptions = appOptions[ADDON_NAME] || {};
+    const env = app.env;
+    this._ENV = env;
     let currentOptions = Object.assign({
         enabled: true,
         helpers: [],
@@ -115,6 +117,9 @@ module.exports = {
       watch,
       templateCompilerPath = undefined
     } = currentOptions;
+    if (env === 'test' || env === 'production') {
+      enabled = false;
+    }
     this._OPTIONS = {
       helpers,
       enabled,

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -285,15 +285,16 @@ function isAngleBrackedComponent(node) {
   return false;
 }
 
-class ASTHotLoadTransform {
+class BaseASTHotLoadTransform {
   constructor() {
     this.syntax = null;
   }
-  transform(ast) {
-    let b = this.syntax.builders;
-    let options = { helpers: [] };
+  static createASTPlugin(config, syntax) {
+    let b = syntax.builders;
+    let options = config || { helpers: [] };
+    // console.log('config', config.addonContext._OPTIONS);
     nestedNames = [];
-    
+
     const visitor = {
       ElementModifierStatement(node) {
         markNodeAsIgnored(node.path);
@@ -349,10 +350,35 @@ class ASTHotLoadTransform {
         convertComponent(node, b, options);
       }
     };
-    this.syntax.traverse(ast, visitor);
-    return ast;
     
+    return {
+      name: 'ember-ast-hot-load',
+      visitor
+    }
   }
 }
 
-module.exports = ASTHotLoadTransform;
+// module.exports = ASTHotLoadTransform;
+
+module.exports = function(config) {
+  return class ASTHotLoadTransform extends BaseASTHotLoadTransform {
+
+    transform(ast) {
+      // let startLoc = ast.loc ? ast.loc.start : {};
+      // /*
+      //   Checking for line and column to avoid registering the plugin for ProgramNode inside a BlockStatement since transform is called for all ProgramNodes in Ember 2.15.X. Removing this would result in minifying all the TextNodes.
+      // */
+      // if (startLoc.line !== 1 || startLoc.column !== 0) {
+      //   return ast;
+      // }
+      const astConfig = config.addonContext._OPTIONS;
+      if (!astConfig.enabled) {
+        return ast;
+      }
+
+      let plugin = ASTHotLoadTransform.createASTPlugin(astConfig, this.syntax);
+      this.syntax.traverse(ast, plugin.visitor);
+      return ast;
+    }
+  };
+};

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -244,7 +244,7 @@ function wrapAngeBrackedComponentWithLetHelper(b, node) {
   ];
   node.path = b.path('let');
   node.hash = b.hash([]);
-  newNode.tag = 'hotLoad' + tagName + Math.random().toString(36).slice(2);
+  newNode.tag = 'HotLoad' + tagName + Math.random().toString(36).slice(2);
   node.program = b.program([newNode], [newNode.tag]);
   node.program['__ignore'] = true;
   node.inverse = null; 

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -2,7 +2,7 @@
 // builders ref https://github.com/glimmerjs/glimmer-vm/blob/master/packages/%40glimmer/syntax/lib/builders.ts
 const HOT_LOAD_HELPER_NAME = "hot-load";
 // for cases like {{#let (component 'foo-bar') as |Boo|}}  <Boo />a {{/let}}
-const nestedNames = [];
+var nestedNames = [];
 
 function createSubExpression(params, b) {
   return b.sexpr(b.path(HOT_LOAD_HELPER_NAME), params);
@@ -285,11 +285,16 @@ function isAngleBrackedComponent(node) {
   return false;
 }
 
-module.exports = function (env, options) {
-  let b = env.syntax.builders;
-  return {
-    name: "ember-ast-hot-load-transform",
-    visitor: {
+class ASTHotLoadTransform {
+  constructor() {
+    this.syntax = null;
+  }
+  transform(ast) {
+    let b = this.syntax.builders;
+    let options = { helpers: [] };
+    nestedNames = [];
+    
+    const visitor = {
       ElementModifierStatement(node) {
         markNodeAsIgnored(node.path);
         node.params.forEach(param => {
@@ -343,6 +348,11 @@ module.exports = function (env, options) {
         }
         convertComponent(node, b, options);
       }
-    }
-  };
-};
+    };
+    this.syntax.traverse(ast, visitor);
+    return ast;
+    
+  }
+}
+
+module.exports = ASTHotLoadTransform;

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -371,8 +371,13 @@ module.exports = function(config) {
       // if (startLoc.line !== 1 || startLoc.column !== 0) {
       //   return ast;
       // }
-      const astConfig = config.addonContext._OPTIONS;
+      const astConfig = config.addonContext._OPTIONS || {};
       if (!astConfig.enabled) {
+        return ast;
+      }
+
+      // cover case for blacklisted addon
+      if (!astConfig.initialized) {
         return ast;
       }
 

--- a/package.json
+++ b/package.json
@@ -60,10 +60,13 @@
     "configPath": "tests/dummy/config",
     "after": [
       "ember-template-component-import",
-      "ember-angle-bracket-invocation-polyfill",
       "ember-holy-futuristic-template-namespacing-batman",
       "ember-template-compiler"
     ],
-    "before": "proxy-server-middleware"
+    "before": [
+      "proxy-server-middleware",
+      "ember-angle-bracket-invocation-polyfill",
+      "ember-let-polyfill"
+    ]
   }
 }

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -8,8 +8,10 @@ module('Acceptance | index', function(hooks) {
   test('visiting /index', async function(assert) {
     await visit('/');
     const hotLoaderService = this.owner.lookup('service:hot-loader');
-    assert.equal(hotLoaderService._willHotReloadCallbacksCount(), hotLoaderService._willLiveReloadCallbacksCount());
-    assert.equal(hotLoaderService._willLiveReloadCallbacksCount() >= 36, true);
+    const cbCount = hotLoaderService._willLiveReloadCallbacksCount();
+    assert.equal(hotLoaderService._willHotReloadCallbacksCount(), cbCount);
+    assert.equal(cbCount >= 36, true);
+    assert.ok(cbCount, 'callbacks must exist '+ cbCount);
     assert.equal(currentURL(), '/');
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | index', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /index', async function(assert) {
+    await visit('/');
+    const hotLoaderService = this.owner.lookup('service:hot-loader');
+    assert.equal(hotLoaderService._willHotReloadCallbacksCount(), hotLoaderService._willLiveReloadCallbacksCount());
+    assert.equal(hotLoaderService._willLiveReloadCallbacksCount(), 20);
+    assert.equal(currentURL(), '/');
+  });
+});

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -9,7 +9,7 @@ module('Acceptance | index', function(hooks) {
     await visit('/');
     const hotLoaderService = this.owner.lookup('service:hot-loader');
     assert.equal(hotLoaderService._willHotReloadCallbacksCount(), hotLoaderService._willLiveReloadCallbacksCount());
-    assert.equal(hotLoaderService._willLiveReloadCallbacksCount(), 20);
+    assert.equal(hotLoaderService._willLiveReloadCallbacksCount(), 36);
     assert.equal(currentURL(), '/');
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -9,7 +9,7 @@ module('Acceptance | index', function(hooks) {
     await visit('/');
     const hotLoaderService = this.owner.lookup('service:hot-loader');
     assert.equal(hotLoaderService._willHotReloadCallbacksCount(), hotLoaderService._willLiveReloadCallbacksCount());
-    assert.equal(hotLoaderService._willLiveReloadCallbacksCount(), 36);
+    assert.equal(hotLoaderService._willLiveReloadCallbacksCount() >= 36, true);
     assert.equal(currentURL(), '/');
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 export default Controller.extend({
-	hotLoader: service(),
 	items: computed(function(){
 		return [1,2,3,4,5,6,7,8];
 	})

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,9 @@
 <h2 id="title">Welcome to Ember</h2>
-
+<style>
+  table td {
+    border: 1px solid black;
+  }
+</style>
 <table>
   <thead>
     <tr>
@@ -13,24 +17,48 @@
       <td>{{template-only}}</td>
     </tr>
     <tr>
+      <td>angle-bracket template-only</td>
+      <td><TemplateOnly /></td>
+    </tr>
+    <tr>
       <td>arg-wrapper itemComponentName="x-test-wrapper"</td>
       <td>{{arg-wrapper itemComponentName="x-test-wrapper"}}</td>
+    </tr>
+    <tr>
+      <td>angle-bracket  arg-wrapper itemComponentName="x-test-wrapper"</td>
+      <td><ArgWrapper @itemComponentName="x-test-wrapper" /></td>
     </tr>
     <tr>
       <td>name-wrapper</td>
       <td>{{name-wrapper}}</td>
     </tr>
     <tr>
+      <td>angle-bracket name-wrapper</td>
+      <td><NameWrapper /></td>
+    </tr>
+    <tr>
       <td>dynamic-component-t</td>
       <td>{{dynamic-component-t}}</td>
+    </tr>
+    <tr>
+      <td>angle-bracket  dynamic-component-t</td>
+      <td><DynamicComponentT /></td>
     </tr>
     <tr>
       <td>x-test-wrapper</td>
       <td>{{x-test-wrapper}}</td>
     </tr>
     <tr>
+      <td>angle-bracket x-test-wrapper</td>
+      <td><XTestWrapper /></td>
+    </tr>
+    <tr>
       <td>test-component</td>
       <td>{{test-component}}</td>
+    </tr>
+    <tr>
+      <td>angle-bracket test-component</td>
+      <td><TestComponent /></td>
     </tr>
     <tr>
       <td>boo-boo 1 2 3 foo="12"</td>
@@ -45,6 +73,10 @@
       <td>{{foo-bar a=true}}</td>
     </tr>
     <tr>
+      <td>angle-bracket foo-bar a=true </td>
+      <td><FooBar @a={{true}} /></td>
+    </tr>
+    <tr>
       <td>
         {#let (hash foo=(component (concat "" "test-component"))) as |bofoo-bar|}
           {bofoo-bar}
@@ -52,7 +84,19 @@
       </td>
       <td>
         {{#let (hash foo=(component (concat "" "test-component"))) as |bofoo-bar|}}
-          {{bofoo-bar}}
+          {{bofoo-bar.foo}}
+        {{/let}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        {#let (hash foo=(component (concat "" "test-component"))) as |FofooBar|}
+           angle-bracket / FofooBar /
+        {/let}
+      </td>
+      <td>
+        {{#let (hash foo=(component (concat "" "test-component"))) as |FofooBar|}}
+          <FofooBar.foo />
         {{/let}}
       </td>
     </tr>


### PR DESCRIPTION
This PR should fix case of anlge-bracked components hot-reloading in ember 3.1

```hbs
{{#each @model.query as |condition|}}
  <PanelQueryGroup
    @model={{condition}}
    @sets={{array
      (array (hash label=2 icon="apple"))
    }}
  />
{{/each}}
```

should be transformed to 
```hbs
{{#each @model.query as |condition|}}  
	{{#let 
		(component (hot-load "PanelQueryGroup" this "PanelQueryGroup" "PanelQueryGroup") hotReloadCUSTOMhlContext=this 
		hotReloadCUSTOMName="PanelQueryGroup" 
		hotReloadCUSTOMhlProperty="PanelQueryGroup" 
		hotReloadCUSTOMHasParams=true 
		hotReloadCUSTOMHasHash=false) 
		as |HotLoadPanelQueryGroupc4cx6g0tbes|}}
		
			<HotLoadPanelQueryGroupc4cx6g0tbes 
				@model={{condition}} 
				@sets={{array (array (hash label=2 icon="apple"))}}>
			</HotLoadPanelQueryGroupc4cx6g0tbes>
	{{/let}}
{{/each}}
```

and handled by "ember-let-polyfill" and "ember-angle-bracket-invocation-polyfill"



- have idea how to pass plugin options from addon & app config

also, this PR should solve https://github.com/lifeart/ember-ast-hot-load/issues/43

fixes case with incorrect ast-plugin invocation on ember 2.16