### PR TITLE
Add support for ember-test-selectors

### DIFF
--- a/addon/components/hot-content.js
+++ b/addon/components/hot-content.js
@@ -11,5 +11,7 @@ export default Component.extend({
     // }
     return this.get('hotReloadCUSTOMhlProperty');
   }),
-  tagName: ''
+  tagName: '',
+  // Support ember-test-selectors https://github.com/simplabs/ember-test-selectors#usage-with-tagless-components
+  supportsDataTestProperties: true
 });

--- a/addon/components/hot-placeholder.js
+++ b/addon/components/hot-placeholder.js
@@ -3,5 +3,7 @@ import layout from "../templates/components/hot-placeholder";
 
 export default Component.extend({
   tagName: "",
-  layout
+  layout,
+  // Support ember-test-selectors https://github.com/simplabs/ember-test-selectors#usage-with-tagless-components
+  supportsDataTestProperties: true
 });


### PR DESCRIPTION
When using this addon in combination with ember-test-selectors it causes an error due to the use of tagless components.

The recommended fix is https://github.com/simplabs/ember-test-selectors#usage-with-tagless-components

This PR adds the require property to the components and should not affect users who don't have ember-test-selectors