### PR TITLE
Compile the dynamic component template without unsafe-eval

### DIFF
--- a/addon/services/hot-loader.js
+++ b/addon/services/hot-loader.js
@@ -20,7 +20,6 @@ import {
 
 import Ember from "ember";
 /* eslint-disable ember/new-module-imports */
-const compileTemplate = Ember.HTMLBars.compile;
 const COMPONENT_NAMES_CACHE = {};
 const DYNAMIC_HELPERS_WRAPPERS_COMPONENTS = {};
 const REQUIRE_CLEAR_CACHE = [];
@@ -29,6 +28,13 @@ var willHotReloadCallbacks = [];
 var willLiveReloadCallbacks = [];
 var matchingResults = {};
 
+function compileTemplate(templateString, options) {
+  let template = Ember.HTMLBars.template;
+  let precompile = Ember.HTMLBars.precompile;
+  let precompiledTemplateString = precompile(templateString, options);
+  let templateJS = JSON.parse(precompiledTemplateString);
+  return template(templateJS);
+}
 
 function stripRouteTemplatePostfix(name) {
   return name.endsWith('.template') ? name.replace('.template', '') : name;


### PR DESCRIPTION
Doing it this way prevents any CSP violation about `unsafe-eval` from happening with this addon.
It does something very similar to `Ember.HTMLBars.compile` here: https://github.com/emberjs/ember.js/blob/master/packages/ember-template-compiler/lib/system/compile.ts

The only difference is the it doesn't create a function, but initializes the template with a static POJO instead.