### PR TITLE
Ignore SSL cert errors when hot reloading.

### DIFF
--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -63,6 +63,7 @@ module.exports = function HotReloader(options, supportedTypes) {
         const path = `${pathname}${search}`;
         await new Promise((resolve, reject) => {
           lsProxy.get({ hostname, port, path, rejectUnauthorized: false }, resolve).on('error', e => {
+            // eslint-disable-next-line no-console
             console.error(e);
             reject(e);
           });

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -8,8 +8,6 @@ var reloadExtensions = ["js", "ts", "hbs"];
 // eslint-disable-next-line
 var reloadJsPattern = new RegExp(".(" + reloadExtensions.join("|") + ")$");
 
-var noop = function() {};
-
 module.exports = function HotReloader(options, supportedTypes) {
   var fsWatcher = options.watcher;
   var ui = options.ui;
@@ -47,7 +45,7 @@ module.exports = function HotReloader(options, supportedTypes) {
     return (filePath.match(appJSPattern) || filePath.match(muAppJSPattern)) ? appJSResource : "vendor.js";
   }
 
-  function fileDidChange(results) {
+  async function fileDidChange(results) {
     var filePath = results.filePath || "";
 
     ui.writeLine(filePath);
@@ -60,10 +58,17 @@ module.exports = function HotReloader(options, supportedTypes) {
       ui.writeLine("Reloading " + filePath + " only");
       try {
         url = liveReloadHostname + "/changed?files=" + filePath;
-        ui.writeLine("GET" + url);
-        lsProxy.get(url).on("error", noop);
+        ui.writeLine("GET " + url);
+        const { hostname, pathname, search, port } = new URL(url);
+        const path = `${pathname}${search}`;
+        await new Promise((resolve, reject) => {
+          lsProxy.get({ hostname, port, path, rejectUnauthorized: false }, resolve).on('error', e => {
+            console.error(e);
+            reject(e);
+          });
+        });
       } catch (e) {
-        ui.writeLine("unknown error hot reloading: " + e);
+        ui.writeLine("Hot reloading error: " + e);
       }
     }
   }


### PR DESCRIPTION
Our local dev environment relies on some self-signed SSL certs which caused problems with hot reloading. This PR allows those errors to be disregarded so hot reloading can work unobstructed. Also made the load request async so that the try/catch block could work as intended.