### PR TITLE
Build the live reload URL in a safer way

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ module.exports = {
       return;
     } else {
       require("./lib/hot-load-middleware")(config, this._OPTIONS).run();
-
-      require("./lib/hot-reloader")(config.options, this._OPTIONS.watch).run();
+      require("./lib/hot-reloader")(config.options).run();
     }
   },
   setupPreprocessorRegistry(type, registry) {

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -33,16 +33,14 @@ module.exports = function HotReloader(options, supportedTypes) {
     options.ssl ? "https://" : "http://",
     options.liveReloadHost || options.host || "localhost",
     ":",
-    options.liveReloadPort +
-      (options.liveReloadPrefix ? "/" + options.liveReloadPrefix : "")
-  ].join("");
+    options.liveReloadPort].join("")
+
+  var liveReloadBaseUrl = new URL(liveReloadHostname);
+  liveReloadBaseUrl.pathname = options.liveReloadPrefix;
+  liveReloadBaseUrl = liveReloadBaseUrl.toString();
 
   function shouldReload(filePath) {
     return filePath.match(reloadJsPattern);
-  }
-
-  function getReloadResource(filePath) {
-    return (filePath.match(appJSPattern) || filePath.match(muAppJSPattern)) ? appJSResource : "vendor.js";
   }
 
   async function fileDidChange(results) {
@@ -51,15 +49,11 @@ module.exports = function HotReloader(options, supportedTypes) {
     ui.writeLine(filePath);
 
     if (shouldReload(filePath)) {
-      // eslint-disable-next-line
-      var reloadResource = getReloadResource(filePath);
-      //   console.log("reloadResource", reloadResource);
-      var url;
       ui.writeLine("Reloading " + filePath + " only");
       try {
-        url = liveReloadHostname + "/changed?files=" + filePath;
-        ui.writeLine("GET " + url);
-        const { hostname, pathname, search, port } = new URL(url);
+        var url = new URL("changed?files=" + filePath, liveReloadBaseUrl);
+        ui.writeLine("GET " + url.toString());
+        const { hostname, pathname, search, port } = url;
         const path = `${pathname}${search}`;
         await new Promise((resolve, reject) => {
           lsProxy.get({ hostname, port, path, rejectUnauthorized: false }, resolve).on('error', e => {

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -2,33 +2,16 @@
 /* global require, module */
 "use strict";
 
-var path = require("path");
 var reloadExtensions = ["js", "ts", "hbs"];
 
-// eslint-disable-next-line
 var reloadJsPattern = new RegExp(".(" + reloadExtensions.join("|") + ")$");
 
-module.exports = function HotReloader(options, supportedTypes) {
+module.exports = function HotReloader(options, _supportedTypes) {
   var fsWatcher = options.watcher;
   var ui = options.ui;
   var _isRunning = false;
   var lsProxy = options.ssl ? require("https") : require("http");
 
-  var appJSPath = supportedTypes
-    .map(function(reloadType) {
-      return path.join(options.project.root, "app", reloadType, "*");
-    })
-	.join("||^");
-
-	var muAppJSPath =  ["routes"].concat(supportedTypes)
-    .map(function(reloadType) {
-      return path.join(options.project.root, "src", "ui", reloadType, "*");
-    })
-	.join("||^");
-
-  var appJSPattern = new RegExp("^" + appJSPath);
-  var muAppJSPattern =  new RegExp("^" + muAppJSPath);
-  var appJSResource = options.project.pkg.name + ".js";
   var liveReloadHostname = [
     options.ssl ? "https://" : "http://",
     options.liveReloadHost || options.host || "localhost",

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -6,7 +6,7 @@ var reloadExtensions = ["js", "ts", "hbs"];
 
 var reloadJsPattern = new RegExp(".(" + reloadExtensions.join("|") + ")$");
 
-module.exports = function HotReloader(options, _supportedTypes) {
+module.exports = function HotReloader(options) {
   var fsWatcher = options.watcher;
   var ui = options.ui;
   var _isRunning = false;

--- a/lib/hot-reloader.test.js
+++ b/lib/hot-reloader.test.js
@@ -1,0 +1,78 @@
+'use strict';
+/* eslint-disable ember/no-invalid-debug-function-arguments */
+/* eslint-env jest */
+/* eslint-env node */
+
+const HotReloader = require('./hot-reloader');
+
+async function testHotReloadChangedUrl(options, expectedUrl) {
+	jest.mock('http');
+	jest.mock('https');
+	const http = require('http');
+	const https = require('https');
+	let fileDidChangeHandler = null;
+	const defaultOptions = {
+		liveReload: true,
+		ui: { writeLine() { } },
+		project: { liveReloadFilterPatterns: [] },
+		watcher: {
+			on(eventName, callback) {
+				if (eventName === "change") {
+					fileDidChangeHandler = callback;
+				}
+			}
+		}
+	};
+
+	let reloader = HotReloader(Object.assign(defaultOptions, options));
+	reloader.run();
+	await fileDidChangeHandler({ filePath: '/components/path/to/my-component.js'});
+
+	const {
+		hostname: expectedHostname,
+		pathname,
+		search,
+		port: expectedPort,
+		protocol: expectedProtocol
+	} = new URL(expectedUrl);
+	const expectedPath = `${pathname}${search}`;
+	let transport = expectedProtocol === 'https:' ? https : http;
+	expect(transport.get).toHaveBeenLastCalledWith({
+		hostname: expectedHostname,
+		path: expectedPath,
+		port: expectedPort,
+		rejectUnauthorized: false
+	}, expect.anything());
+}
+
+it('requests the correct change URL for the default live reload options', async () => {
+	await testHotReloadChangedUrl({}, 'http://localhost/changed?files=/components/path/to/my-component.js');
+});
+
+it('requests the correct change URL when the live reload prefix is /', async () => {
+	const options = {
+		liveReloadHost: 'my-host.test',
+		liveReloadPort: 36629,
+		liveReloadPrefix: '/'
+	};
+	await testHotReloadChangedUrl(options, 'http://my-host.test:36629/changed?files=/components/path/to/my-component.js');
+});
+
+it('requests the correct change URL when the live reload prefix ends with a /', async () => {
+	const options = {
+		liveReloadHost: 'my-host.test',
+		liveReloadPort: 1234,
+		liveReloadPrefix: '/this/is/my/path/'
+	};
+	await testHotReloadChangedUrl(options, 'http://my-host.test:1234/this/is/my/path/changed?files=/components/path/to/my-component.js');
+});
+
+it('requests the correct change URL when the live reload server uses SSL', async () => {
+	const options = {
+		liveReloadHost: 'my-host.test',
+		liveReloadPort: 1234,
+		liveReloadPrefix: '',
+		ssl: true
+	};
+	await testHotReloadChangedUrl(options, 'https://my-host.test:1234/changed?files=/components/path/to/my-component.js');
+});


### PR DESCRIPTION
In our project, the `liveReloadPrefix` is option set to `/`. So any changes to a component results in the following URL being triggered: `///changes`.

This PR fixes that. I haven't used jest before so happy to take any pointers :)