### PR TITLE
Add support for standalone components hot-reload

### DIFF
--- a/addon/services/hot-loader.js
+++ b/addon/services/hot-loader.js
@@ -137,7 +137,7 @@ export default Service.extend(Evented, {
     return window.location.reload();
   },
   willHotReloadRouteTemplate(attrs) {
-    const meta = getPossibleRouteTemplateMeta(attrs);
+    const meta = getPossibleRouteTemplateMeta(attrs, this.podModulePrefix);
     if (!meta.looksLikeRouteTemplate) {
       return;
     }
@@ -193,7 +193,7 @@ export default Service.extend(Evented, {
     }
   },
   willLiveReloadRouteTemplate(attrs) {
-    const meta = getPossibleRouteTemplateMeta(attrs.modulePath);
+    const meta = getPossibleRouteTemplateMeta(attrs.modulePath, this.podModulePrefix);
     if (meta.looksLikeRouteTemplate) {
       attrs.cancel  = true;
       this.clearRequirejs(meta.possibleTemplateName);

--- a/addon/utils/matchers.js
+++ b/addon/utils/matchers.js
@@ -49,23 +49,34 @@ export function matchingComponent(rawComponentName, path) {
   return result;
 }
 
-const templateStartRegExp = /^[\s\S]*([/\\]pods[/\\])/i;
+const stringEscapeRegExp = /[.*+?^${}()|[\]\\]/g;
 const templateEndRegExp = /template\.hbs$/i;
 const windowsSeparatorRegExp = /\\/g;
+const regExpCache = {};
 
-export function looksLikeRouteTemplate(path) {
+function cachePodRegExp(podModulePrefix) {
+  regExpCache[podModulePrefix] = regExpCache[podModulePrefix] ||
+    new RegExp(`^[\\s\\S]*([/\\\\]${podModulePrefix.replace(stringEscapeRegExp, '\\$&')}[/\\\\])`, 'i')
+
+  return regExpCache[podModulePrefix];
+}
+
+export function looksLikeRouteTemplate(path, podModulePrefix = 'pods') {
   // mu app case
   if (path.includes('/src/ui/')) {
     return path.includes('/routes/') && path.endsWith('/template.hbs') && !path.includes('/-components/');
   }
 
   // Strip pod paths
-  const templatePath = path.replace(templateStartRegExp, '$1').replace(templateEndRegExp, '');
+  const templatePath = normalizePath(path).replace(cachePodRegExp(podModulePrefix), '$1').replace(templateEndRegExp, '');
   const reverseSeparatorPath = templatePath.replace(windowsSeparatorRegExp, '/');
+
   const hasComponent = Object.keys(window.requirejs ? window.requirejs.entries : {})
     .some(name => name.endsWith(`${templatePath}component`) || name.endsWith(`${reverseSeparatorPath}component`));
 
-  return !path.includes('component') && path.endsWith('.hbs') && !path.endsWith('-loading.hbs') && !hasComponent;
+  return !path.includes('component') && path.endsWith('.hbs') &&
+         !path.endsWith('-loading.hbs') && !path.endsWith('-error.hbs') &&
+         !hasComponent;
 }
 
 

--- a/addon/utils/matchers.js
+++ b/addon/utils/matchers.js
@@ -40,7 +40,7 @@ export function matchingComponent(rawComponentName, path) {
     "/template.hbs"
   ];
   let possibleEndings = possibleExtensions.map(ext => componentName + ext);
-  
+
   const classicIgnores = ['app/controllers/','app/helpers/','app/services/','app/utils/', 'app/adapters/', 'app/models/', 'app/routes/'];
   let result = possibleEndings.filter((name) => {
     return normalizedPath.endsWith('/' + name) && classicIgnores.filter((substr) => normalizedPath.includes(substr)).length === 0;
@@ -49,15 +49,21 @@ export function matchingComponent(rawComponentName, path) {
   return result;
 }
 
+const templateStartRegExp = /^[\s\S]*([/\\]pods[/\\])/i;
+const templateEndRegExp = /template\.hbs$/i;
+const windowsSeparatorRegExp = /\\/g;
+
 export function looksLikeRouteTemplate(path) {
   // mu app case
   if (path.includes('/src/ui/')) {
     return path.includes('/routes/') && path.endsWith('/template.hbs') && !path.includes('/-components/');
   }
 
-  const templatePath = path.replace(/^[\s\S]*\/app\//i, '').replace(/template\.hbs$/i, '');
+  // Strip pod paths
+  const templatePath = path.replace(templateStartRegExp, '$1').replace(templateEndRegExp, '');
+  const reverseSeparatorPath = templatePath.replace(windowsSeparatorRegExp, '/');
   const hasComponent = Object.keys(window.requirejs ? window.requirejs.entries : {})
-    .some(name=>name.endsWith(`${templatePath}component`));
+    .some(name => name.endsWith(`${templatePath}component`) || name.endsWith(`${reverseSeparatorPath}component`));
 
   return !path.includes('component') && path.endsWith('.hbs') && !path.endsWith('-loading.hbs') && !hasComponent;
 }

--- a/addon/utils/matchers.js
+++ b/addon/utils/matchers.js
@@ -54,7 +54,12 @@ export function looksLikeRouteTemplate(path) {
   if (path.includes('/src/ui/')) {
     return path.includes('/routes/') && path.endsWith('/template.hbs') && !path.includes('/-components/');
   }
-  return !path.includes('component') && path.endsWith('.hbs') && !path.endsWith('-loading.hbs');
+
+  const templatePath = path.replace(/^[\s\S]*\/app\//i, '').replace(/template\.hbs$/i, '');
+  const hasComponent = Object.keys(window.requirejs ? window.requirejs.entries : {})
+    .some(name=>name.endsWith(`${templatePath}component`));
+
+  return !path.includes('component') && path.endsWith('.hbs') && !path.endsWith('-loading.hbs') && !hasComponent;
 }
 
 

--- a/addon/utils/normalizers.js
+++ b/addon/utils/normalizers.js
@@ -53,7 +53,7 @@ export function normalizeComponentName(name) {
   }
 }
 
-export function getPossibleRouteTemplateMeta(maybeString = '') {
+export function getPossibleRouteTemplateMeta(maybeString = '', podModulePrefix) {
   const rawPath = String(maybeString || '');
   const path = normalizePath(rawPath).split('/').join('.').replace('.hbs', '');
   const MU_PATH = '.src.ui';
@@ -67,7 +67,7 @@ export function getPossibleRouteTemplateMeta(maybeString = '') {
   const possibleRouteName = maybeRouteName.replace('templates.', '').replace('routes.','');
 
   return {
-    looksLikeRouteTemplate: looksLikeRouteTemplate(normalizePath(rawPath)),
+    looksLikeRouteTemplate: looksLikeRouteTemplate(normalizePath(rawPath), podModulePrefix),
     possibleRouteName,
     possibleTemplateName: possibleRouteName.split('.').join('/'),
     maybeClassicPath,

--- a/tests/dummy/app/foo-pods/pods/route-foo-bar/foo-bar/component.js
+++ b/tests/dummy/app/foo-pods/pods/route-foo-bar/foo-bar/component.js
@@ -1,0 +1,1 @@
+// Dummy file to confirm that this folder holds a component for matcher tests that directly use requirejs.

--- a/tests/dummy/app/pods/route-foo-bar/foo-bar/component.js
+++ b/tests/dummy/app/pods/route-foo-bar/foo-bar/component.js
@@ -1,0 +1,1 @@
+// Dummy file to confirm that this folder holds a component for matcher tests that directly use requirejs.

--- a/tests/unit/utils/matchers-test.js
+++ b/tests/unit/utils/matchers-test.js
@@ -107,7 +107,29 @@ module('Unit | Utility | matchers', function() {
       assert.equal(looksLikeRouteTemplate(location), true, `location ${location} should look like route template`);
     });
     invalidLocations('foo-bar').forEach((location)=>{
-      assert.equal(looksLikeRouteTemplate(location, true), false, `location ${location} should not look like route template`);
+      assert.equal(looksLikeRouteTemplate(location), false, `location ${location} should not look like route template`);
+    });
+  });
+
+  test('looksLikeRouteTemplate should return true for classic, pods and mu structure with custom pods location', function(assert){
+    function validLocations(name) {
+      const locations =  [
+        `app/foo-pods/pods/route-${name}/template.hbs`,
+      ];
+      return [].concat(locations, locations.map((location)=>location.toString().replace(/\//gi,'\\')));
+    }
+    function invalidLocations(name) {
+      const locations =  [
+        `app/foo-pods/pods/components/${name}/template.hbs`,
+        `app/foo-pods/pods/route-${name}/${name}/template.hbs`,
+      ];
+      return [].concat(locations, locations.map((location)=>location.toString().replace(/\//gi,'\\')));
+    }
+    validLocations('foo-bar').forEach((location)=>{
+      assert.equal(looksLikeRouteTemplate(location, 'foo-pods/pods'), true, `location ${location} should look like route template`);
+    });
+    invalidLocations('foo-bar').forEach((location)=>{
+      assert.equal(looksLikeRouteTemplate(location, 'foo-pods/pods'), false, `location ${location} should not look like route template`);
     });
   });
 });

--- a/tests/unit/utils/matchers-test.js
+++ b/tests/unit/utils/matchers-test.js
@@ -1,4 +1,4 @@
-import { 
+import {
   hasValidHelperName,
   isValidComponentExtension,
   matchingComponent,
@@ -55,11 +55,14 @@ module('Unit | Utility | matchers', function() {
         `ui/components/${name}/component.ts`,
         `ui/routes/route-${name}/-components/${name}/template.hbs`,
         `ui/routes/route-${name}/-components/${name}/component.js`,
-        `ui/routes/route-${name}/-components/${name}/component.ts`
+        `ui/routes/route-${name}/-components/${name}/component.ts`,
+        `ui/routes/route-${name}/${name}/${name}/template.hbs`,
+        `ui/routes/route-${name}/${name}/${name}/component.js`,
+        `ui/routes/route-${name}/${name}/${name}/component.ts`
       ];
       return [].concat(locations, locations.map((location)=>location.toString().replace(/\//gi,'\\')));
     }
-    
+
     validLocations('foo').forEach((path)=>{
       assert.equal(matchingComponent('foo', path), true, `foo should match ${path}`);
       assert.equal(matchingComponent('food', path), false, `food should not match ${path}`);
@@ -80,11 +83,11 @@ module('Unit | Utility | matchers', function() {
     });
   });
 
-  test('looksLikeRouteTemplate should return true for classic, pods and mu strictire', function(assert){
+  test('looksLikeRouteTemplate should return true for classic, pods and mu structure', function(assert){
     function validLocations(name) {
       const locations =  [
         `ui/routes/${name}/template.hbs`,
-        `app/pods/${name}/template.hbs`,
+        `app/pods/route-${name}/template.hbs`,
         `app/routes/${name}/template.hbs`,
         `app/templates/${name}.hbs`
       ];
@@ -94,16 +97,17 @@ module('Unit | Utility | matchers', function() {
       const locations =  [
         `ui/routes/${name}/-components/foo/template.hbs`,
         `app/pods/components/${name}/template.hbs`,
+        `app/pods/route-${name}/${name}/template.hbs`,
         `app/routes/${name}/template.js`,
         `app/templates/components/${name}.hbs`
       ];
       return [].concat(locations, locations.map((location)=>location.toString().replace(/\//gi,'\\')));
     }
     validLocations('foo-bar').forEach((location)=>{
-      assert.equal(looksLikeRouteTemplate(location), true, `location ${location} should looks like route template`);
+      assert.equal(looksLikeRouteTemplate(location), true, `location ${location} should look like route template`);
     });
     invalidLocations('foo-bar').forEach((location)=>{
-      assert.equal(looksLikeRouteTemplate(location), false, `location ${location} should not looks like route template`);
+      assert.equal(looksLikeRouteTemplate(location, true), false, `location ${location} should not look like route template`);
     });
   });
 });


### PR DESCRIPTION
Currently hot-reload doesn't work for components that are children of their route - the whole page is reloaded. Checking if there is a component file in the same folder should cover for those cases.

Can you please also backport this PR to 0.1.x and release a version, as I'm using Ember 3.6 and upgrade is far fetched.