### PR TITLE
Use Ember's algorithm for dasherizing component names 

### DIFF
--- a/addon/utils/normalizers.js
+++ b/addon/utils/normalizers.js
@@ -23,33 +23,29 @@ export function normalizePath(path) {
   return dasherizePath(path.split("\\").join("/"));
 }
 
+// Take from https://github.com/emberjs/ember.js/blob/b31998b6a0cccd22a8fb6fab21d24e5e7f2cb70d/packages/ember-template-compiler/lib/system/dasherize-component-name.ts
 // we need this because Ember.String.dasherize('XTestWrapper') -> xtest-wrapper, not x-test-wrapper
+const SIMPLE_DASHERIZE_REGEXP = /[A-Z]|::/g;
+const ALPHA = /[A-Za-z0-9]/;
 export function dasherizeName(name = '') {
-	const result = [];
-	const nameSize = name.length;
-	if (!nameSize) {
-		return '';
-	}
-	result.push(name.charAt(0));
-	for (let i = 1; i < nameSize; i++) {
-		let char = name.charAt(i);
-		if (char === char.toUpperCase()) {
-			if (char !== '-' && char !== '/' && char !== '_') {
-				if (result[result.length - 1] !== '-' && result[result.length - 1] !== '/') {
-					result.push('-');
-				}
-			}
-		}
-		result.push(char);
-	}
-	return result.join('');
+  return name.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
+    if (char === '::') {
+      return '/';
+    }
+
+    if (index === 0 || !ALPHA.test(name[index - 1])) {
+      return char.toLowerCase();
+    }
+
+    return `-${char.toLowerCase()}`;
+  })
 }
 
 export function normalizeComponentName(name) {
   if (typeof name !== 'string') {
     return name;
   } else {
-    return dasherizeName(name).toLowerCase();
+    return dasherizeName(name);
   }
 }
 

--- a/tests/unit/utils/normalizers-test.js
+++ b/tests/unit/utils/normalizers-test.js
@@ -16,6 +16,7 @@ module('Unit | Utility | normalizers', function() {
     assert.equal(componentNameFromClassName('FooBarClass'), 'foo-bar');
     assert.equal(componentNameFromClassName('FooBarComponent'), 'foo-bar');
     assert.equal(componentNameFromClassName('XFooBarClassComponent'), 'x-foo-bar');
+    assert.equal(componentNameFromClassName('FooV2'), 'foo-v2');
   });
 
   test('dasherizePath should dasherize camelized paths', function(assert){
@@ -27,10 +28,10 @@ module('Unit | Utility | normalizers', function() {
   });
 
   test('dasherizeName should convert component names to valid form', function(assert) {
-    assert.equal(dasherizeName('XFooBar'), 'X-Foo-Bar');
-    assert.equal(dasherizeName('XFooBar/BooBaz'), 'X-Foo-Bar/Boo-Baz');
-    assert.equal(dasherizeName('FooBar/BooBaz'), 'Foo-Bar/Boo-Baz');
-    assert.equal(dasherizeName('Foo/Boo'), 'Foo/Boo');
+    assert.equal(dasherizeName('XFooBar'), 'x-foo-bar');
+    assert.equal(dasherizeName('XFooBar/BooBaz'), 'x-foo-bar/boo-baz');
+    assert.equal(dasherizeName('FooBar/BooBaz'), 'foo-bar/boo-baz');
+    assert.equal(dasherizeName('Foo/Boo'), 'foo/boo');
   });
 
   test('normalizeComponentName should convert component name to valid lowercased form', function(assert){


### PR DESCRIPTION
I came across an issue in my app today where only the name of the component was being rendered and a `<HotContent />` component was being rendered in its place. After a bit of debugging I discovered that internally ember-ast-hot-load was converting the component's camel cased named to the wrong dasherized format. The component's name was `ComposerV2` but it was being dasherized as `composer-v-2` where it actually should be `composer-v2`.

Rather than rely on a custom implementation of the dasherize functionality I've replaced it with a copy of Ember's own internal logic from [dasherize-component-name.ts](https://github.com/emberjs/ember.js/blob/b31998b6a0cccd22a8fb6fab21d24e5e7f2cb70d/packages/ember-template-compiler/lib/system/dasherize-component-name.ts)
