### PR TITLE
Fix hot reloading 

### DIFF
--- a/addon/utils/cleaners.js
+++ b/addon/utils/cleaners.js
@@ -88,7 +88,7 @@ function requireUnsee(module) {
 // }
 
 function addonComponents(modulePrefix) {
-  return Object.keys(window.require.entries).filter(
+  return Object.keys(window.requirejs.entries).filter(
     name => !name.startsWith(modulePrefix)
   );
 }

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -34,7 +34,7 @@ module.exports = function HotReloader(options) {
     if (shouldReload(filePath)) {
       ui.writeLine("Reloading " + filePath + " only");
       try {
-        var url = new URL("changed?files=" + filePath, liveReloadBaseUrl);
+        var url = new URL(`${options.liveReloadPrefix}/changed?files=` + filePath, liveReloadBaseUrl);
         ui.writeLine("GET " + url.toString());
         const { hostname, pathname, search, port } = url;
         const path = `${pathname}${search}`;


### PR DESCRIPTION
I believe these changes fix #445.

Reference to `window.require` resulted in a null object being passed to Object.keys and an exception being thrown. Also added the `liveReloadPrefix` to the generated hot reload `GET` request URL. Otherwise, live reload was not being made aware of the changed files. This might be a result of now passing in the `liveReoloadBaseUrl` when creating it. From my reading, that base URL shouldn't have a path on it and I'm not sure how it handles one being there. 

https://nodejs.org/api/url.html#url_new_url_input_base