### PR TITLE
Potential fix for hot reload prefix issue

### DIFF
--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -34,7 +34,11 @@ module.exports = function HotReloader(options) {
     if (shouldReload(filePath)) {
       ui.writeLine("Reloading " + filePath + " only");
       try {
-        var url = new URL(`${options.liveReloadPrefix}changed?files=` + filePath, liveReloadBaseUrl);
+        var prefix = options.liveReloadPrefix;
+        if (!prefix.endsWith('/')) {
+          prefix = `${prefix}/`;
+        }
+        var url = new URL(`${prefix}changed?files=` + filePath, liveReloadBaseUrl);
         ui.writeLine("GET " + url.toString());
         const { hostname, pathname, search, port } = url;
         const path = `${pathname}${search}`;

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -34,7 +34,7 @@ module.exports = function HotReloader(options) {
     if (shouldReload(filePath)) {
       ui.writeLine("Reloading " + filePath + " only");
       try {
-        var url = new URL(`${options.liveReloadPrefix}/changed?files=` + filePath, liveReloadBaseUrl);
+        var url = new URL(`${options.liveReloadPrefix}changed?files=` + filePath, liveReloadBaseUrl);
         ui.writeLine("GET " + url.toString());
         const { hostname, pathname, search, port } = url;
         const path = `${pathname}${search}`;


### PR DESCRIPTION
Potential fix for the issue discovered after merging https://github.com/lifeart/ember-ast-hot-load/pull/488

If you have your `liveReloadPrefix` set to `/` the URL return is invalid and live reloading will fail to work