### PR TITLE
Fix `deprecated-run-loop-and-computed-dot-access` deprecation

### DIFF
--- a/addon/components/hot-content.js
+++ b/addon/components/hot-content.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
 import layout from '../templates/components/hot-content';
-import { computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
 
 export default Component.extend({
   layout,
-  value: computed.reads('hotReloadCUSTOMhlProperty'),
+  value: reads('hotReloadCUSTOMhlProperty'),
   tagName: '',
   // Support ember-test-selectors https://github.com/simplabs/ember-test-selectors#usage-with-tagless-components
   supportsDataTestProperties: true,


### PR DESCRIPTION
This usage is currently logging a long deprecation notice to the browser console.